### PR TITLE
Fix to nav_layer_from_points setting cost the position of cliff_detector/points

### DIFF
--- a/cliff_detector/src/cliff_detector.cpp
+++ b/cliff_detector/src/cliff_detector.cpp
@@ -446,12 +446,16 @@ void CliffDetector::findCliffInDepthImage( const sensor_msgs::ImageConstPtr &dep
     // Calculate point in XZ plane -- depth (z)
     //pt.z = (float)(*it)[Depth] * tilt_compensation_factor_[(*it)[Row]] / 1000.0f;
     unsigned int row = (*it)[Row];
-    pt.z = sensor_mount_height_ / std::tan(sensor_tilt_angle_ * M_PI / 180.0 + delta_row_[row]);
+    // pt.z = sensor_mount_height_ / std::tan(sensor_tilt_angle_ * M_PI / 180.0 + delta_row_[row]); // comment out by hwata
 
-    // Calculate x value
     // pt.x = ((*it)[Col] - camera_model_.cx()) * (*it)[Depth] / camera_model_.fx() / 1000.0f;
     double depth = sensor_mount_height_ / std::sin(sensor_tilt_angle_*M_PI/180.0 + delta_row_[row]);
-
+    // Calculate z value
+    pt.z = depth;
+    // Calculate y value
+    pt.y = depth * std::sin(delta_row_[row]);
+    // << add by hwata
+    // Calculate x value
     pt.x = ((*it)[Col] - camera_model_.cx()) * depth / camera_model_.fx();
 
     // Add point to message

--- a/nav_layer_from_points/cfg/NavLayerFromPoints.cfg
+++ b/nav_layer_from_points/cfg/NavLayerFromPoints.cfg
@@ -5,7 +5,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 gen = ParameterGenerator()
 
 gen.add("enabled",      bool_t,   0, "Whether to apply this plugin or not ",            True)
-gen.add("keep_time",    double_t, 0, "Pause before clearing points list",               0.75, 0.0,2.0)
+gen.add("keep_time",    double_t, 0, "Pause before clearing points list",               10.0, 0.0,60.0)
 gen.add("point_radius", double_t, 0, "Radius of points which will be add to costmap",   0.2, 0.0, 2.0)
 gen.add("robot_radius", double_t, 0, "Radius of the robot",                             0.6, 0.1, 2.0)
 

--- a/nav_layer_from_points/costmap_plugins.xml
+++ b/nav_layer_from_points/costmap_plugins.xml
@@ -1,5 +1,5 @@
 <library path="lib/libcostmap_layers">
-  <class type="nav_layer_from_points::NavLayerPoints" base_class_type="costmap_2d::Layer">
+  <class type="nav_layer_from_points::NavLayerFromPoints" base_class_type="costmap_2d::Layer">
     <description>Uses points information to change the costmap</description>
   </class>
 </library>

--- a/nav_layer_from_points/include/nav_layer_from_points/costmap_layer.h
+++ b/nav_layer_from_points/include/nav_layer_from_points/costmap_layer.h
@@ -39,6 +39,7 @@
 
 #include <ros/ros.h>
 #include <costmap_2d/layered_costmap.h>
+#include <costmap_2d/costmap_layer.h>
 #include <costmap_2d/footprint.h>
 #include <costmap_2d/layer.h>
 #include <pluginlib/class_list_macros.h>
@@ -46,25 +47,22 @@
 #include <depth_nav_msgs/Point32List.h>
 #include <geometry_msgs/PointStamped.h>
 
-#include <boost/thread.hpp>
-
-#include <tf/transform_listener.h>
-
 #include <math.h>
-#include <algorithm>
-
 #include <angles/angles.h>
-
+#include <tf/transform_listener.h>
 #include <dynamic_reconfigure/server.h>
 #include <nav_layer_from_points/NavLayerFromPointsConfig.h>
 
+#include <algorithm>
+#include <boost/thread.hpp>
 
 namespace nav_layer_from_points
 {
-class NavLayerFromPoints : public costmap_2d::Layer
+class NavLayerFromPoints : public costmap_2d::CostmapLayer
 {
 public:
-  NavLayerFromPoints() { layered_costmap_ = NULL; }
+  NavLayerFromPoints();
+  virtual ~NavLayerFromPoints();
 
   virtual void onInitialize();
 
@@ -77,6 +75,9 @@ public:
   void updateBoundsFromPoints( double* min_x, double* min_y,
                                double* max_x, double* max_y);
 
+  virtual void activate();
+  virtual void deactivate();
+  virtual void reset();
   bool isDiscretized() { return false; }
 
 protected:

--- a/nav_layer_from_points/src/costmap_layer.cpp
+++ b/nav_layer_from_points/src/costmap_layer.cpp
@@ -120,7 +120,7 @@ namespace nav_layer_from_points
       try
       {
         pt.point.x = tpt.point.x;
-        pt.point.y = 0;
+        pt.point.y = tpt.point.y;
         pt.point.z =  tpt.point.z;
         pt.header.frame_id = points_list_.header.frame_id;
 


### PR DESCRIPTION
## Summary
 nav_layer_from_points setting cost the position of cliff_detector/points

### Detail
 - Subscribe topics when publish not only depth but also points.(9e2cd26)
 - To fix the position of cliff_detector/points from the depth camera frame.(ad5d7d9) 
 - To fix move_base died when clear costmap service, nav_layer_from_points override from CostmapLayer.(b140155)
 - by above, nav_layer_from_points can generate the cost at the position of cliff_detector/points.